### PR TITLE
[ONE-5648] Add Gemini code review styleguide

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,10 @@
+have_fun: true
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: false
+    code_review: true
+    include_drafts: false

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -15,7 +15,7 @@ This file is self-contained so Gemini Code Assist can review this repo without f
 
 ## Kong Plugin Development
 
-- These repos are Lua Kong plugin packages, not NestJS services, frontend apps, or generic TypeScript packages. Review Kong/OpenResty runtime behavior, plugin schema, rockspec packaging, and API Gateway compatibility first.
+- These repos are Lua Kong plugin packages. Review Kong/OpenResty runtime behavior, plugin schema, rockspec packaging, and API Gateway compatibility first.
 - Treat plugin name, phase handlers, `PRIORITY`, `VERSION`, schema fields, defaults, required settings, protocol support, and entity checks as public API. Changes can break Kong declarative config, service-generated OpenAPI annotations, or the API Gateway Docker image.
 - Keep rockspec names and versions, plugin source paths under `kong/plugins/<plugin-name>`, README installation docs, test fixtures, and any API Gateway install scripts or pinned tags in sync.
 - Be careful with plugin execution order. Priority changes can alter authentication, authorization, path rewriting, and upstream request mutation when multiple plugins run on the same request.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -5,12 +5,6 @@
 
 This file is self-contained so Gemini Code Assist can review this repo without following links to companion docs.
 
-## Release PRs
-
-If this PR targets the `prod` branch, do not perform a full code review. FactoryFix `staging` to `prod` pull requests are release PRs where code has already been reviewed before it reached `staging`.
-
-For `prod` PRs, post a short, creative deployment blessing or well-wish instead of review comments. Keep it brief and different each time.
-
 ## Review Tone
 
 - Be pragmatic and question-first. Prefer "Have you considered...?" or "Any reason not to...?" for non-blocking feedback.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -19,52 +19,15 @@ For `prod` PRs, post a short, creative deployment blessing or well-wish instead 
 - Avoid style-only comments unless the issue creates real confusion or violates an established repo convention.
 - Prefer a small number of high-signal comments over many low-value nits.
 
-## Backend Architecture
+## Package APIs and Libraries
 
-- Keep clean architecture boundaries intact: controllers handle transport concerns, use cases own business logic, and persistence/adapters only fetch, store, or send data.
-- Controllers should translate HTTP or messaging inputs into use case calls. They should not contain business rules, persistence calls, or cross-service orchestration.
-- Use cases should expose a single clear `execute()` entry point for a business flow. Split separate flows into separate use cases when branching logic stops being trivial.
-- Persistence classes should not validate business rules, throw HTTP exceptions, or decide what missing data means. Return data or `null` and let the caller decide.
-- Do not add DAO interfaces, wrapper services, or abstractions unless they remove real complexity or match an existing local pattern.
-
-## Error Handling and Logging
-
-- Preserve stack traces. Pass real `Error` objects through error paths instead of converting them to strings.
-- Use `logger.error(error)` only when the error is handled and will not be rethrown. This creates Google Cloud Error Reporting events.
-- Use `logger.warn()` when adding context before throwing or rethrowing. Avoid duplicate Error Reporting events for the same failure.
-- Do not log errors with interpolated strings such as ``logger.error(`message: ${error}`)`` because that loses stack trace details.
-- Persistence methods that catch storage or API errors should wrap them in the repo's established persistence error type when one exists.
-- Use cases should not throw NestJS HTTP exceptions such as `BadRequestException`, `NotFoundException`, or `InternalServerErrorException`.
-- Domain/use case code should throw domain errors that extend `Error`. Controllers are responsible for mapping domain errors to HTTP exceptions.
-- Avoid `console.log`, `console.warn`, and `console.error` in application code. Use the repo's logger.
-
-## Security and Authorization
-
-- Service-to-service calls should use FactoryFix service auth helpers such as `@factoryfixinc/nest-auth`. Do not forward user tokens between services.
-- Validate ownership and authorization at the boundary before acting on employer IDs, user IDs, project IDs, application IDs, subscription IDs, or organization IDs.
-- Protected endpoints should have the repo's established auth guards. Flag missing guards on new controllers or routes.
-- Check for insecure direct object reference risks when a caller can provide an entity ID.
-- Do not introduce secrets, tokens, credentials, or private keys in source files, docs, tests, Terraform, or example configs.
-- Infrastructure changes should use least-privilege IAM roles and Secret Manager references for sensitive values.
-
-## Testing
-
-- New controllers, use cases, and critical branches should have focused tests.
-- Prefer testing domain/use case behavior over thin persistence or adapter wrappers.
-- Co-locate Jest unit specs next to the source files when that is the local pattern.
-- Use repo scripts such as `yarn test`, `yarn lint`, `yarn build`, or `./bin/run-tests.sh`; do not suggest ad-hoc `npx` commands.
-- For Docker-only repos, expect commands to run through Docker Compose or the repo's bootstrap/test scripts.
-- Tests should cover happy paths, meaningful error paths, and edge cases such as missing data, zero values, authorization failures, and duplicate requests.
-- Avoid tests that only assert mocks were called without proving user-visible or domain behavior.
-
-## Data, Performance, and Operations
-
-- New database queries should have appropriate migrations and indexes. Flag large-table filters that lack index coverage.
-- Avoid loading unbounded datasets into memory. Prefer pagination, batching, streaming, or query limits.
-- Avoid N+1 access patterns and repeated updates to the same entity when a single update would work.
-- Prefer `promisePool()` for independent async work over collections. It is better than serially awaiting independent operations and safer than `Promise.all()` or `Promise.allSettled()` over unbounded arrays because it keeps concurrency explicit.
-- Choose a concurrency limit based on downstream database, API, queue, or rate-limit constraints. Name the limit with a clear constant when the value is not obvious.
-- If all-settled behavior is required, use the repo's bounded settled-pool utility when available instead of unbounded `Promise.allSettled()`.
-- Firestore multi-document or read-modify-write flows should use transactions when partial updates would create inconsistent state.
-- Pub/Sub topics, Cloud Tasks queues, and environment variables must be configured in all required places: service config, local Docker/test config, and infrastructure config.
-- Alerting and monitoring changes should include actionable runbook context where the local infrastructure pattern supports it.
+- Treat exported symbols as a public API. Flag changes to exported names, types, runtime behavior, module options, or generated artifacts that could break consuming repos.
+- Keep package entry points in sync with implementation changes, especially `src/index.ts`, generated type declarations, package `main`/`types` fields, and documented import paths.
+- Package code should stay reusable and consumer-agnostic. Avoid service-specific environment variables, controllers, queues, database migrations, Cloud Run assumptions, or application orchestration unless that is the package's explicit purpose.
+- Do not add runtime dependencies casually. Prefer existing dependencies, keep framework dependencies compatible with consuming services, and use peer dependencies when consumers are expected to provide the framework package.
+- Preserve stack traces and typed errors. Generic packages should throw normal `Error` subclasses or package-specific errors, not NestJS HTTP exceptions, unless the package is explicitly an HTTP transport helper.
+- Security-sensitive packages, such as auth, guard, token, or request-context helpers, should avoid logging credentials or tokens and should include tests for authorization edge cases.
+- Type-only, DTO, or interface packages should avoid adding runtime behavior unless it is already part of the package pattern.
+- Utility functions that process collections should keep concurrency bounded when they perform independent async work. Prefer the repo's bounded utility, such as `promisePool()`, over serial awaits or unbounded `Promise.all()` / `Promise.allSettled()`.
+- Tests should cover the package's public API, compatibility behavior, exported types where practical, error paths, and edge cases that would affect consumers.
+- Use the package's existing build, lint, and test scripts. Do not suggest service-only commands, Docker service stacks, database migrations, or deployment checks for package-only changes.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -19,15 +19,23 @@ For `prod` PRs, post a short, creative deployment blessing or well-wish instead 
 - Avoid style-only comments unless the issue creates real confusion or violates an established repo convention.
 - Prefer a small number of high-signal comments over many low-value nits.
 
-## Package APIs and Libraries
+## Kong Plugin Development
 
-- Treat exported symbols as a public API. Flag changes to exported names, types, runtime behavior, module options, or generated artifacts that could break consuming repos.
-- Keep package entry points in sync with implementation changes, especially `src/index.ts`, generated type declarations, package `main`/`types` fields, and documented import paths.
-- Package code should stay reusable and consumer-agnostic. Avoid service-specific environment variables, controllers, queues, database migrations, Cloud Run assumptions, or application orchestration unless that is the package's explicit purpose.
-- Do not add runtime dependencies casually. Prefer existing dependencies, keep framework dependencies compatible with consuming services, and use peer dependencies when consumers are expected to provide the framework package.
-- Preserve stack traces and typed errors. Generic packages should throw normal `Error` subclasses or package-specific errors, not NestJS HTTP exceptions, unless the package is explicitly an HTTP transport helper.
-- Security-sensitive packages, such as auth, guard, token, or request-context helpers, should avoid logging credentials or tokens and should include tests for authorization edge cases.
-- Type-only, DTO, or interface packages should avoid adding runtime behavior unless it is already part of the package pattern.
-- Utility functions that process collections should keep concurrency bounded when they perform independent async work. Prefer the repo's bounded utility, such as `promisePool()`, over serial awaits or unbounded `Promise.all()` / `Promise.allSettled()`.
-- Tests should cover the package's public API, compatibility behavior, exported types where practical, error paths, and edge cases that would affect consumers.
-- Use the package's existing build, lint, and test scripts. Do not suggest service-only commands, Docker service stacks, database migrations, or deployment checks for package-only changes.
+- These repos are Lua Kong plugin packages, not NestJS services, frontend apps, or generic TypeScript packages. Review Kong/OpenResty runtime behavior, plugin schema, rockspec packaging, and API Gateway compatibility first.
+- Treat plugin name, phase handlers, `PRIORITY`, `VERSION`, schema fields, defaults, required settings, protocol support, and entity checks as public API. Changes can break Kong declarative config, service-generated OpenAPI annotations, or the API Gateway Docker image.
+- Keep rockspec names and versions, plugin source paths under `kong/plugins/<plugin-name>`, README installation docs, test fixtures, and any API Gateway install scripts or pinned tags in sync.
+- Be careful with plugin execution order. Priority changes can alter authentication, authorization, path rewriting, and upstream request mutation when multiple plugins run on the same request.
+- Prefer Kong APIs such as `kong.request`, `kong.service.request`, `kong.response`, `kong.client`, and `kong.log` over direct `ngx` access when the Kong API supports the operation. Direct `ngx` usage should be intentional and compatible with the relevant phase.
+- Do not log secrets, bearer tokens, ID tokens, service account keys, client secrets, userinfo payloads, or other sensitive headers. Debug logs in plugins can become gateway-wide operational exposure.
+- Schema changes should be backward-compatible unless the rollout plan updates every Kong config that uses the plugin. Flag changed defaults, renamed config fields, relaxed auth behavior, or widened protocol applicability.
+- Runtime changes should preserve Kong/OpenResty compatibility for the supported Kong versions. Avoid dependencies, Lua APIs, or Docker assumptions that the plugin test environment and API Gateway image do not provide.
+- Path, header, credential, cache, auth, and response-code behavior should have focused plugin tests when changed. Use the repo's Docker, Pongo, Makefile, or existing test scripts rather than service-only commands.
+
+## kong-plugin-upstream-google-id-token Notes
+
+- This plugin injects a Google ID token for upstream Cloud Run service-to-service auth. Preserve the default header `X-Serverless-Authorization` so end-user `Authorization` headers remain separate.
+- Audience calculation is part of the security contract. It currently derives the target audience from Kong's routed service protocol and host; changes should be tested against Cloud Run IAM expectations.
+- Preserve both credential modes: metadata server token retrieval in GCP and service-account-key based token retrieval via `GOOGLE_APPLICATION_CREDENTIALS` for non-GCP environments.
+- Keep token caching bounded by Google ID token lifetime. Changes to `id_token_cache_ttl`, cache keys, or refresh behavior can cause auth failures, excess metadata/API calls, or wrong-audience token reuse.
+- Do not log ID tokens, signed JWT assertions, service account private keys, service account JSON content, or upstream auth headers.
+- Verification should use Pongo tests for schema and token injection behavior, plus an API Gateway image/build check when packaging, rockspec, or dependency changes affect installation.

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,70 @@
+<!-- Generated from the docs repo: docs/process/tools/gemini-code-review. -->
+<!-- Edit the source docs, then run bin/render-gemini-styleguides.sh. -->
+
+# FactoryFix Gemini Code Review Style Guide
+
+This file is self-contained so Gemini Code Assist can review this repo without following links to companion docs.
+
+## Release PRs
+
+If this PR targets the `prod` branch, do not perform a full code review. FactoryFix `staging` to `prod` pull requests are release PRs where code has already been reviewed before it reached `staging`.
+
+For `prod` PRs, post a short, creative deployment blessing or well-wish instead of review comments. Keep it brief and different each time.
+
+## Review Tone
+
+- Be pragmatic and question-first. Prefer "Have you considered...?" or "Any reason not to...?" for non-blocking feedback.
+- Block only on correctness, security, data integrity, broken behavior, or missing tests for changed critical flows.
+- Praise useful patterns when they are present.
+- Avoid style-only comments unless the issue creates real confusion or violates an established repo convention.
+- Prefer a small number of high-signal comments over many low-value nits.
+
+## Backend Architecture
+
+- Keep clean architecture boundaries intact: controllers handle transport concerns, use cases own business logic, and persistence/adapters only fetch, store, or send data.
+- Controllers should translate HTTP or messaging inputs into use case calls. They should not contain business rules, persistence calls, or cross-service orchestration.
+- Use cases should expose a single clear `execute()` entry point for a business flow. Split separate flows into separate use cases when branching logic stops being trivial.
+- Persistence classes should not validate business rules, throw HTTP exceptions, or decide what missing data means. Return data or `null` and let the caller decide.
+- Do not add DAO interfaces, wrapper services, or abstractions unless they remove real complexity or match an existing local pattern.
+
+## Error Handling and Logging
+
+- Preserve stack traces. Pass real `Error` objects through error paths instead of converting them to strings.
+- Use `logger.error(error)` only when the error is handled and will not be rethrown. This creates Google Cloud Error Reporting events.
+- Use `logger.warn()` when adding context before throwing or rethrowing. Avoid duplicate Error Reporting events for the same failure.
+- Do not log errors with interpolated strings such as ``logger.error(`message: ${error}`)`` because that loses stack trace details.
+- Persistence methods that catch storage or API errors should wrap them in the repo's established persistence error type when one exists.
+- Use cases should not throw NestJS HTTP exceptions such as `BadRequestException`, `NotFoundException`, or `InternalServerErrorException`.
+- Domain/use case code should throw domain errors that extend `Error`. Controllers are responsible for mapping domain errors to HTTP exceptions.
+- Avoid `console.log`, `console.warn`, and `console.error` in application code. Use the repo's logger.
+
+## Security and Authorization
+
+- Service-to-service calls should use FactoryFix service auth helpers such as `@factoryfixinc/nest-auth`. Do not forward user tokens between services.
+- Validate ownership and authorization at the boundary before acting on employer IDs, user IDs, project IDs, application IDs, subscription IDs, or organization IDs.
+- Protected endpoints should have the repo's established auth guards. Flag missing guards on new controllers or routes.
+- Check for insecure direct object reference risks when a caller can provide an entity ID.
+- Do not introduce secrets, tokens, credentials, or private keys in source files, docs, tests, Terraform, or example configs.
+- Infrastructure changes should use least-privilege IAM roles and Secret Manager references for sensitive values.
+
+## Testing
+
+- New controllers, use cases, and critical branches should have focused tests.
+- Prefer testing domain/use case behavior over thin persistence or adapter wrappers.
+- Co-locate Jest unit specs next to the source files when that is the local pattern.
+- Use repo scripts such as `yarn test`, `yarn lint`, `yarn build`, or `./bin/run-tests.sh`; do not suggest ad-hoc `npx` commands.
+- For Docker-only repos, expect commands to run through Docker Compose or the repo's bootstrap/test scripts.
+- Tests should cover happy paths, meaningful error paths, and edge cases such as missing data, zero values, authorization failures, and duplicate requests.
+- Avoid tests that only assert mocks were called without proving user-visible or domain behavior.
+
+## Data, Performance, and Operations
+
+- New database queries should have appropriate migrations and indexes. Flag large-table filters that lack index coverage.
+- Avoid loading unbounded datasets into memory. Prefer pagination, batching, streaming, or query limits.
+- Avoid N+1 access patterns and repeated updates to the same entity when a single update would work.
+- Prefer `promisePool()` for independent async work over collections. It is better than serially awaiting independent operations and safer than `Promise.all()` or `Promise.allSettled()` over unbounded arrays because it keeps concurrency explicit.
+- Choose a concurrency limit based on downstream database, API, queue, or rate-limit constraints. Name the limit with a clear constant when the value is not obvious.
+- If all-settled behavior is required, use the repo's bounded settled-pool utility when available instead of unbounded `Promise.allSettled()`.
+- Firestore multi-document or read-modify-write flows should use transactions when partial updates would create inconsistent state.
+- Pub/Sub topics, Cloud Tasks queues, and environment variables must be configured in all required places: service config, local Docker/test config, and infrastructure config.
+- Alerting and monitoring changes should include actionable runbook context where the local infrastructure pattern supports it.


### PR DESCRIPTION
## Summary
- add Gemini auto-review config for non-draft PRs
- add FactoryFix Gemini code review styleguide
- keep generated styleguides in sync with the docs repo source

## Verification
- regenerated with docs/bin/render-gemini-styleguides.sh
- checked generated config/styleguide patterns across rendered repos
- git diff --check